### PR TITLE
Feature pagination completed

### DIFF
--- a/src/interfaces/DTO/pagination.dto.ts
+++ b/src/interfaces/DTO/pagination.dto.ts
@@ -1,0 +1,36 @@
+import { IsInt, IsOptional, Max, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class PaginationQueryDto {
+  @ApiPropertyOptional({ description: 'Page number (1-indexed)', example: 1, default: 1 })
+  @IsOptional()
+  @IsInt({ message: 'page must be an integer' })
+  @Min(1, { message: 'page must be at least 1' })
+  @Type(() => Number)
+  page: number = 1;
+
+  @ApiPropertyOptional({ description: 'Items per page (max 100)', example: 20, default: 20 })
+  @IsOptional()
+  @IsInt({ message: 'limit must be an integer' })
+  @Min(1, { message: 'limit must be at least 1' })
+  @Max(100, { message: 'limit must not exceed 100' })
+  @Type(() => Number)
+  limit: number = 20;
+}
+
+export class PaginatedResponseDto<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+
+  constructor(data: T[], total: number, page: number, limit: number) {
+    this.data = data;
+    this.total = total;
+    this.page = page;
+    this.limit = limit;
+    this.totalPages = total === 0 ? 0 : Math.ceil(total / limit);
+  }
+}

--- a/src/services/api-keys/api-keys.controller.spec.ts
+++ b/src/services/api-keys/api-keys.controller.spec.ts
@@ -2,6 +2,7 @@ import { ApiKeysController } from './api-keys.controller';
 import { ApiKeysService } from './api-keys.service';
 import { CreateApiKeyDTO } from 'src/interfaces/DTO/api-key.dto';
 import { ApiKeyEntity } from 'src/entities/api-key.entity';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 describe('ApiKeysController', () => {
   let controller: ApiKeysController;
@@ -52,12 +53,19 @@ describe('ApiKeysController', () => {
     expect(service.create).toHaveBeenCalledWith(dto, request);
   });
 
-  it('should return all api keys from the service', async () => {
+  it('should return all api keys as a paginated response', async () => {
     const apiKeys = [{ id: apiKeyId } as ApiKeyEntity];
-    service.findAll.mockResolvedValue(apiKeys);
+    const query = new PaginationQueryDto();
+    const paginated = new PaginatedResponseDto(apiKeys, 1, query.page, query.limit);
+    service.findAll.mockResolvedValue(paginated);
 
-    await expect(controller.findAll()).resolves.toEqual(apiKeys);
-    expect(service.findAll).toHaveBeenCalledTimes(1);
+    const result = await controller.findAll(query);
+    expect(result.data).toEqual(apiKeys);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
+    expect(service.findAll).toHaveBeenCalledWith(query);
   });
 
   it('should deactivate an api key via the service', async () => {

--- a/src/services/api-keys/api-keys.controller.ts
+++ b/src/services/api-keys/api-keys.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
   UseInterceptors,
@@ -19,9 +20,12 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiSecurity,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiExtraModels,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { ApiKeyEntity } from 'src/entities/api-key.entity';
 import { AuthGuard } from 'src/common/guards/auth.guard';
@@ -31,6 +35,7 @@ import * as requestWithApi from 'src/interfaces/request-api-key';
 import * as requestUser from 'src/interfaces/request-user';
 import { EndpointKey } from 'src/common/decorators/endpoint-key.decorator';
 import { AssignPermissionDTO } from 'src/interfaces/DTO/assign.dto';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @ApiTags('API Keys')
 @Controller('api-keys')
@@ -97,12 +102,26 @@ export class ApiKeysController {
   @UseInterceptors(ClassSerializerInterceptor)
   @ApiCookieAuth('auth_token')
   @ApiOperation({ summary: 'List all API keys' })
-  @ApiOkResponse({ type: [ApiKeyEntity] })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiExtraModels(ApiKeyEntity)
+  @ApiOkResponse({
+    description: 'Paginated list of API keys',
+    schema: {
+      properties: {
+        data: { type: 'array', items: { $ref: getSchemaPath(ApiKeyEntity) } },
+        total: { type: 'integer', example: 42 },
+        page: { type: 'integer', example: 1 },
+        limit: { type: 'integer', example: 20 },
+        totalPages: { type: 'integer', example: 3 },
+      },
+    },
+  })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid auth cookie' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @Get('all')
-  findAll(): Promise<ApiKeyEntity[]> {
-    return this.apiKeysService.findAll();
+  findAll(@Query() query: PaginationQueryDto): Promise<PaginatedResponseDto<ApiKeyEntity>> {
+    return this.apiKeysService.findAll(query);
   }
 
   @UseGuards(AuthGuard)

--- a/src/services/api-keys/api-keys.repository.ts
+++ b/src/services/api-keys/api-keys.repository.ts
@@ -32,6 +32,7 @@ export class ApiKeysRepository {
       relations: ['permissions'],
       skip: (page - 1) * limit,
       take: limit,
+      order: { client: 'ASC' },
     });
   }
 

--- a/src/services/api-keys/api-keys.repository.ts
+++ b/src/services/api-keys/api-keys.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ApiKeyEntity } from 'src/entities/api-key.entity';
 import { EntityManager, In, Repository } from 'typeorm';
+import { PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class ApiKeysRepository {
@@ -25,8 +26,13 @@ export class ApiKeysRepository {
     });
   }
 
-  async findAll(): Promise<ApiKeyEntity[]> {
-    return await this.ormRepository.find({ relations: ['permissions'] });
+  async findAll(query: PaginationQueryDto): Promise<[ApiKeyEntity[], number]> {
+    const { page, limit } = query;
+    return await this.ormRepository.findAndCount({
+      relations: ['permissions'],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
   }
 
   async findAllActive(): Promise<ApiKeyEntity[]> {

--- a/src/services/api-keys/api-keys.service.spec.ts
+++ b/src/services/api-keys/api-keys.service.spec.ts
@@ -3,6 +3,7 @@ import { ApiKeysService } from './api-keys.service';
 import { ApiKeysRepository } from './api-keys.repository';
 import { ApiKeyEntity } from 'src/entities/api-key.entity';
 import { ApiKeyErrorCodes, ApiKeyException } from 'src/services/api-keys/api-keys.exception.handler';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 // Mock node:crypto — HMAC-SHA256 replaces bcrypt
 const MOCK_PLAIN_KEY = 'ab'.repeat(32); // 64 hex chars from randomBytes(32)
@@ -142,11 +143,20 @@ describe('ApiKeysService', () => {
 
   // ── findAll ─────────────────────────────────────────────────────────
 
-  it('findAll returns API keys with relations', async () => {
-    (repository.findAll as jest.Mock).mockResolvedValue([{ id: apiKeyId }]);
+  it('findAll returns a PaginatedResponseDto wrapping API keys', async () => {
+    const keys = [{ id: apiKeyId }];
+    (repository.findAll as jest.Mock).mockResolvedValue([keys, 1]);
 
-    await expect(service.findAll()).resolves.toEqual([{ id: apiKeyId }]);
-    expect(repository.findAll).toHaveBeenCalled();
+    const query = new PaginationQueryDto();
+    const result = await service.findAll(query);
+
+    expect(result).toBeInstanceOf(PaginatedResponseDto);
+    expect(result.data).toEqual(keys);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
+    expect(repository.findAll).toHaveBeenCalledWith(query);
   });
 
   // ── findOne ─────────────────────────────────────────────────────────

--- a/src/services/api-keys/api-keys.service.ts
+++ b/src/services/api-keys/api-keys.service.ts
@@ -12,6 +12,7 @@ import { RequestWithUser } from 'src/interfaces/request-user';
 import { ApiKeyErrorCodes, ApiKeyException } from 'src/services/api-keys/api-keys.exception.handler';
 import { ApiKeysRepository } from 'src/services/api-keys/api-keys.repository';
 import { RedisService } from 'src/common/redis/redis.service';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { serializeError } from 'src/common/utils/logger-format.util';
@@ -75,9 +76,10 @@ export class ApiKeysService implements OnModuleInit {
     }
   }
 
-  async findAll(): Promise<ApiKeyEntity[]> {
+  async findAll(query: PaginationQueryDto = new PaginationQueryDto()): Promise<PaginatedResponseDto<ApiKeyEntity>> {
     try {
-      return await this.apiKeysRepository.findAll();
+      const [data, total] = await this.apiKeysRepository.findAll(query);
+      return new PaginatedResponseDto(data, total, query.page, query.limit);
     } catch (error) {
       throw new ApiKeyException(
         'Api keys not found',

--- a/src/services/endpoint-permission-rules/endpoint-permission-rules.controller.spec.ts
+++ b/src/services/endpoint-permission-rules/endpoint-permission-rules.controller.spec.ts
@@ -1,5 +1,7 @@
 import { EndpointPermissionRulesController } from './endpoint-permission-rules.controller';
 import { EndpointPermissionRulesService } from './endpoint-permission-rules.service';
+import { EndpointPermissionRulesEntity } from 'src/entities/endpoint-permission-rules.entity';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 describe('EndpointPermissionRulesController', () => {
   let controller: EndpointPermissionRulesController;
@@ -13,6 +15,8 @@ describe('EndpointPermissionRulesController', () => {
       assignPermissions: jest.fn(),
       enableRule: jest.fn(),
       disableRule: jest.fn(),
+      findAll: jest.fn(),
+      findOne: jest.fn(),
     } as unknown as jest.Mocked<EndpointPermissionRulesService>;
 
     controller = new EndpointPermissionRulesController(service);
@@ -20,5 +24,20 @@ describe('EndpointPermissionRulesController', () => {
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  it('should list all endpoint permission rules as a paginated response', async () => {
+    const rules = [{ id: 'rule-1', endpoint_key_name: 'users.create' }] as EndpointPermissionRulesEntity[];
+    const query = new PaginationQueryDto();
+    const paginated = new PaginatedResponseDto(rules, 1, query.page, query.limit);
+    service.findAll.mockResolvedValue(paginated);
+
+    const result = await controller.findAll(query);
+    expect(result.data).toEqual(rules);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
+    expect(service.findAll).toHaveBeenCalledWith(query);
   });
 });

--- a/src/services/endpoint-permission-rules/endpoint-permission-rules.controller.ts
+++ b/src/services/endpoint-permission-rules/endpoint-permission-rules.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
   UseInterceptors,
@@ -30,10 +31,14 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiSecurity,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiExtraModels,
+  getSchemaPath,
 } from '@nestjs/swagger';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @ApiTags('Endpoint Permission Rules')
 @Controller('endpoint-permission-rules')
@@ -138,12 +143,26 @@ export class EndpointPermissionRulesController {
   @EndpointKey('endpoint-permission-rules.find')
   @ApiCookieAuth('auth_token')
   @ApiOperation({ summary: 'List all endpoint permission rules' })
-  @ApiOkResponse({ type: [EndpointPermissionRulesEntity] })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiExtraModels(EndpointPermissionRulesEntity)
+  @ApiOkResponse({
+    description: 'Paginated list of endpoint permission rules',
+    schema: {
+      properties: {
+        data: { type: 'array', items: { $ref: getSchemaPath(EndpointPermissionRulesEntity) } },
+        total: { type: 'integer', example: 42 },
+        page: { type: 'integer', example: 1 },
+        limit: { type: 'integer', example: 20 },
+        totalPages: { type: 'integer', example: 3 },
+      },
+    },
+  })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid auth cookie' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @Get('all')
-  findAll(): Promise<EndpointPermissionRulesEntity[]> {
-    return this.endpointPermissionRulesService.findAll();
+  findAll(@Query() query: PaginationQueryDto): Promise<PaginatedResponseDto<EndpointPermissionRulesEntity>> {
+    return this.endpointPermissionRulesService.findAll(query);
   }
 
   @UseGuards(AuthGuard)

--- a/src/services/endpoint-permission-rules/endpoint-permission-rules.repository.ts
+++ b/src/services/endpoint-permission-rules/endpoint-permission-rules.repository.ts
@@ -35,6 +35,7 @@ export class EndpointPermissionRulesRepository {
     return await this.ormRepository.findAndCount({
       skip: (page - 1) * limit,
       take: limit,
+      order: { endpoint_key_name: 'ASC' },
     });
   }
 

--- a/src/services/endpoint-permission-rules/endpoint-permission-rules.repository.ts
+++ b/src/services/endpoint-permission-rules/endpoint-permission-rules.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { EndpointPermissionRulesEntity } from 'src/entities/endpoint-permission-rules.entity';
+import { PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class EndpointPermissionRulesRepository {
@@ -29,8 +30,12 @@ export class EndpointPermissionRulesRepository {
     return await this.ormRepository.findOneBy({ id });
   }
 
-  async findAll(): Promise<EndpointPermissionRulesEntity[]> {
-    return await this.ormRepository.find();
+  async findAll(query: PaginationQueryDto): Promise<[EndpointPermissionRulesEntity[], number]> {
+    const { page, limit } = query;
+    return await this.ormRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+    });
   }
 
   async findByEndpointKey(endpointKeyName: string): Promise<EndpointPermissionRulesEntity | null> {

--- a/src/services/endpoint-permission-rules/endpoint-permission-rules.service.spec.ts
+++ b/src/services/endpoint-permission-rules/endpoint-permission-rules.service.spec.ts
@@ -5,6 +5,7 @@ import { RedisService } from 'src/common/redis/redis.service';
 import { EndpointPermissionRulesEntity } from 'src/entities/endpoint-permission-rules.entity';
 import { EndpointPRException } from 'src/services/endpoint-permission-rules/endpoint-permission-rules.exception';
 import { Logger } from 'winston';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 // ────────────────────────────────────────────────────────────────
 // Helpers
@@ -359,6 +360,24 @@ describe('EndpointPermissionRulesService', () => {
         await service.disableRule('rule-1');
 
         expect(invalidateRuleCacheSpy).toHaveBeenCalledWith('users.disable');
+      });
+    });
+
+    describe('findAll()', () => {
+      it('returns a PaginatedResponseDto wrapping all endpoint permission rules', async () => {
+        const rules = [makeRule({ endpoint_key_name: 'users.create' })];
+        repository.findAll.mockResolvedValue([rules, 1]);
+
+        const query = new PaginationQueryDto();
+        const result = await service.findAll(query);
+
+        expect(result).toBeInstanceOf(PaginatedResponseDto);
+        expect(result.data).toEqual(rules);
+        expect(result.total).toBe(1);
+        expect(result.page).toBe(1);
+        expect(result.limit).toBe(20);
+        expect(result.totalPages).toBe(1);
+        expect(repository.findAll).toHaveBeenCalledWith(query);
       });
     });
 

--- a/src/services/endpoint-permission-rules/endpoint-permission-rules.service.ts
+++ b/src/services/endpoint-permission-rules/endpoint-permission-rules.service.ts
@@ -1,6 +1,7 @@
 import { HttpStatus, Inject, Injectable, OnModuleInit } from '@nestjs/common';
 import { EndpointPermissionRulesRepository } from 'src/services/endpoint-permission-rules/endpoint-permission-rules.repository';
 import { PermissionsService } from 'src/services/permissions/permissions.service';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 import {
   CreateEndpointPermissionRulesDTO,
   PatchEndpointPermissionRulesDTO,
@@ -220,9 +221,12 @@ export class EndpointPermissionRulesService implements OnModuleInit {
     return endpointPermissionRule;
   }
 
-  async findAll(): Promise<EndpointPermissionRulesEntity[]> {
+  async findAll(
+    query: PaginationQueryDto = new PaginationQueryDto(),
+  ): Promise<PaginatedResponseDto<EndpointPermissionRulesEntity>> {
     try {
-      return await this.endpointPermissionRulesRepository.findAll();
+      const [data, total] = await this.endpointPermissionRulesRepository.findAll(query);
+      return new PaginatedResponseDto(data, total, query.page, query.limit);
     } catch (error) {
       throw new EndpointPRException(
         'Endpoint Permission Rules not found',

--- a/src/services/permissions/permissions.controller.spec.ts
+++ b/src/services/permissions/permissions.controller.spec.ts
@@ -3,6 +3,7 @@ import { PermissionsService } from './permissions.service';
 import { CreatePermissionDTO } from 'src/interfaces/DTO/create.dto';
 import { PatchPermissionDTO } from 'src/interfaces/DTO/patch.dto';
 import { PermissionEntity } from 'src/entities/permission.entity';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 describe('PermissionsController', () => {
   let controller: PermissionsController;
@@ -66,14 +67,21 @@ describe('PermissionsController', () => {
     expect(service.findOne).toHaveBeenCalledWith(permissionId);
   });
 
-  it('should list all permissions', async () => {
+  it('should list all permissions as a paginated response', async () => {
     const permissions = [
       { id: permissionId, code: 'P1' },
       { id: secondPermissionId, code: 'P2' },
     ] as PermissionEntity[];
-    service.findAll.mockResolvedValue(permissions);
+    const query = new PaginationQueryDto();
+    const paginated = new PaginatedResponseDto(permissions, 2, query.page, query.limit);
+    service.findAll.mockResolvedValue(paginated);
 
-    await expect(controller.findAll()).resolves.toEqual(permissions);
-    expect(service.findAll).toHaveBeenCalledTimes(1);
+    const result = await controller.findAll(query);
+    expect(result.data).toEqual(permissions);
+    expect(result.total).toBe(2);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
+    expect(service.findAll).toHaveBeenCalledWith(query);
   });
 });

--- a/src/services/permissions/permissions.controller.ts
+++ b/src/services/permissions/permissions.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
   UseInterceptors,
@@ -21,13 +22,17 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiExtraModels,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { PermissionEntity } from 'src/entities/permission.entity';
 import { CreatePermissionDTO } from 'src/interfaces/DTO/create.dto';
 import * as requestUser from 'src/interfaces/request-user';
 import { EndpointKey } from 'src/common/decorators/endpoint-key.decorator';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @ApiTags('Permissions')
 @ApiCookieAuth('auth_token')
@@ -95,11 +100,25 @@ export class PermissionsController {
   @EndpointKey('permission.find')
   @UseInterceptors(ClassSerializerInterceptor)
   @ApiOperation({ summary: 'Find all permissions' })
-  @ApiOkResponse({ type: [PermissionEntity] })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiExtraModels(PermissionEntity)
+  @ApiOkResponse({
+    description: 'Paginated list of permissions',
+    schema: {
+      properties: {
+        data: { type: 'array', items: { $ref: getSchemaPath(PermissionEntity) } },
+        total: { type: 'integer', example: 42 },
+        page: { type: 'integer', example: 1 },
+        limit: { type: 'integer', example: 20 },
+        totalPages: { type: 'integer', example: 3 },
+      },
+    },
+  })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid auth cookie' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @Get('all')
-  findAll(): Promise<PermissionEntity[]> {
-    return this.permissionService.findAll();
+  findAll(@Query() query: PaginationQueryDto): Promise<PaginatedResponseDto<PermissionEntity>> {
+    return this.permissionService.findAll(query);
   }
 }

--- a/src/services/permissions/permissions.repository.ts
+++ b/src/services/permissions/permissions.repository.ts
@@ -32,6 +32,7 @@ export class PermissionsRepository {
     return await this.ormRepository.findAndCount({
       skip: (page - 1) * limit,
       take: limit,
+      order: {code: 'ASC'}
     });
   }
 

--- a/src/services/permissions/permissions.repository.ts
+++ b/src/services/permissions/permissions.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PermissionEntity } from 'src/entities/permission.entity';
 import { Repository } from 'typeorm';
+import { PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class PermissionsRepository {
@@ -26,8 +27,12 @@ export class PermissionsRepository {
     return await this.ormRepository.findOneBy({ id });
   }
 
-  async findAll(): Promise<PermissionEntity[]> {
-    return await this.ormRepository.find();
+  async findAll(query: PaginationQueryDto): Promise<[PermissionEntity[], number]> {
+    const { page, limit } = query;
+    return await this.ormRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+    });
   }
 
   async remove(permission: PermissionEntity): Promise<void> {

--- a/src/services/permissions/permissions.service.spec.ts
+++ b/src/services/permissions/permissions.service.spec.ts
@@ -1,6 +1,7 @@
 import { PermissionsRepository } from './permissions.repository';
 import { PermissionsService } from './permissions.service';
 import { PermissionsException } from './permissions.exception';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 describe('PermissionsService', () => {
   let permissionRepository: jest.Mocked<Partial<PermissionsRepository>>;
@@ -84,9 +85,18 @@ describe('PermissionsService', () => {
     await expect(service.findOne(missingPermissionId)).rejects.toBeInstanceOf(PermissionsException);
   });
 
-  it('findAll returns list of permissions', async () => {
-    (permissionRepository.findAll as jest.Mock).mockResolvedValue([{ id: permissionId, code: 'PERM' }]);
+  it('findAll returns a PaginatedResponseDto wrapping all permissions', async () => {
+    const permissions = [{ id: permissionId, code: 'PERM' }];
+    (permissionRepository.findAll as jest.Mock).mockResolvedValue([permissions, 1]);
 
-    await expect(service.findAll()).resolves.toEqual([{ id: permissionId, code: 'PERM' }]);
+    const query = new PaginationQueryDto();
+    const result = await service.findAll(query);
+
+    expect(result).toBeInstanceOf(PaginatedResponseDto);
+    expect(result.data).toEqual(permissions);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
   });
 });

--- a/src/services/permissions/permissions.service.ts
+++ b/src/services/permissions/permissions.service.ts
@@ -5,6 +5,7 @@ import { PatchPermissionDTO } from 'src/interfaces/DTO/patch.dto';
 import { RequestWithUser } from 'src/interfaces/request-user';
 import { PermissionsRepository } from 'src/services/permissions/permissions.repository';
 import { PermissionsErrorCodes, PermissionsException } from 'src/services/permissions/permissions.exception';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class PermissionsService {
@@ -67,9 +68,10 @@ export class PermissionsService {
     return permission;
   }
 
-  async findAll(): Promise<PermissionEntity[]> {
+  async findAll(query: PaginationQueryDto = new PaginationQueryDto()): Promise<PaginatedResponseDto<PermissionEntity>> {
     try {
-      return await this.permissionRepository.findAll();
+      const [data, total] = await this.permissionRepository.findAll(query);
+      return new PaginatedResponseDto(data, total, query.page, query.limit);
     } catch (error) {
       throw new PermissionsException(
         'Permissions not found',

--- a/src/services/roles/roles.controller.spec.ts
+++ b/src/services/roles/roles.controller.spec.ts
@@ -4,6 +4,7 @@ import { CreateRoleDTO } from 'src/interfaces/DTO/create.dto';
 import { PatchRoleDTO } from 'src/interfaces/DTO/patch.dto';
 import { AssignPermissionDTO } from 'src/interfaces/DTO/assign.dto';
 import { RoleEntity } from 'src/entities/role.entity';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 describe('RolesController', () => {
   let controller: RolesController;
@@ -78,11 +79,18 @@ describe('RolesController', () => {
     expect(service.findOne).toHaveBeenCalledWith(roleId);
   });
 
-  it('should list all roles', async () => {
+  it('should list all roles as a paginated response', async () => {
     const roles = [{ id: roleId, name: 'a' }] as RoleEntity[];
-    service.findAll.mockResolvedValue(roles);
+    const query = new PaginationQueryDto();
+    const paginated = new PaginatedResponseDto(roles, 1, query.page, query.limit);
+    service.findAll.mockResolvedValue(paginated);
 
-    await expect(controller.findAll()).resolves.toEqual(roles);
-    expect(service.findAll).toHaveBeenCalledTimes(1);
+    const result = await controller.findAll(query);
+    expect(result.data).toEqual(roles);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
+    expect(service.findAll).toHaveBeenCalledWith(query);
   });
 });

--- a/src/services/roles/roles.controller.ts
+++ b/src/services/roles/roles.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Delete, Get, Param, Patch, Post, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from '@nestjs/common';
 import { RolesService } from 'src/services/roles/roles.service';
 import { AuthGuard } from 'src/common/guards/auth.guard';
 import {
@@ -9,8 +9,11 @@ import {
   ApiOkResponse,
   ApiOperation,
   ApiParam,
+  ApiQuery,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiExtraModels,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import { RoleEntity } from 'src/entities/role.entity';
 import { AssignPermissionDTO } from 'src/interfaces/DTO/assign.dto';
@@ -18,6 +21,7 @@ import { PatchRoleDTO } from 'src/interfaces/DTO/patch.dto';
 import * as requestUser from 'src/interfaces/request-user';
 import { CreateRoleDTO } from 'src/interfaces/DTO/create.dto';
 import { EndpointKey } from 'src/common/decorators/endpoint-key.decorator';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @ApiTags('Roles')
 @ApiCookieAuth('auth_token')
@@ -93,11 +97,25 @@ export class RolesController {
   @UseGuards(AuthGuard)
   @EndpointKey('roles.find')
   @ApiOperation({ summary: 'Find all roles' })
-  @ApiOkResponse({ type: [RoleEntity] })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiExtraModels(RoleEntity)
+  @ApiOkResponse({
+    description: 'Paginated list of roles',
+    schema: {
+      properties: {
+        data: { type: 'array', items: { $ref: getSchemaPath(RoleEntity) } },
+        total: { type: 'integer', example: 42 },
+        page: { type: 'integer', example: 1 },
+        limit: { type: 'integer', example: 20 },
+        totalPages: { type: 'integer', example: 3 },
+      },
+    },
+  })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid auth cookie' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @Get('all')
-  findAll(): Promise<RoleEntity[]> {
-    return this.rolesService.findAll();
+  findAll(@Query() query: PaginationQueryDto): Promise<PaginatedResponseDto<RoleEntity>> {
+    return this.rolesService.findAll(query);
   }
 }

--- a/src/services/roles/roles.repository.ts
+++ b/src/services/roles/roles.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { RoleEntity } from 'src/entities/role.entity';
 import { Repository } from 'typeorm';
+import { PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class RolesRepository {
@@ -26,8 +27,12 @@ export class RolesRepository {
     return await this.ormRepository.findOneBy({ id });
   }
 
-  async findAll(): Promise<RoleEntity[]> {
-    return await this.ormRepository.find();
+  async findAll(query: PaginationQueryDto): Promise<[RoleEntity[], number]> {
+    const { page, limit } = query;
+    return await this.ormRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+    });
   }
 
   async remove(role: RoleEntity): Promise<void> {

--- a/src/services/roles/roles.repository.ts
+++ b/src/services/roles/roles.repository.ts
@@ -32,6 +32,7 @@ export class RolesRepository {
     return await this.ormRepository.findAndCount({
       skip: (page - 1) * limit,
       take: limit,
+      order: { name: 'ASC' },
     });
   }
 

--- a/src/services/roles/roles.service.spec.ts
+++ b/src/services/roles/roles.service.spec.ts
@@ -4,6 +4,7 @@ import { PermissionsService } from '../permissions/permissions.service';
 import { RolesException } from './roles.exception';
 import { SessionsService } from 'src/services/sessions/sessions.service';
 import { Logger } from 'winston';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 describe('RolesService', () => {
   let roleRepository: jest.Mocked<Partial<RolesRepository>>;
@@ -101,10 +102,19 @@ describe('RolesService', () => {
     await expect(service.findOne(otherRoleId)).rejects.toBeInstanceOf(RolesException);
   });
 
-  it('findAll returns all roles', async () => {
-    (roleRepository.findAll as jest.Mock).mockResolvedValue([{ id: roleId, name: 'ADMIN' }]);
+  it('findAll returns a PaginatedResponseDto wrapping all roles', async () => {
+    const roles = [{ id: roleId, name: 'ADMIN' }];
+    (roleRepository.findAll as jest.Mock).mockResolvedValue([roles, 1]);
 
-    await expect(service.findAll()).resolves.toEqual([{ id: roleId, name: 'ADMIN' }]);
+    const query = new PaginationQueryDto();
+    const result = await service.findAll(query);
+
+    expect(result).toBeInstanceOf(PaginatedResponseDto);
+    expect(result.data).toEqual(roles);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
   });
 
   it('assignPermissions loads permissions and saves role', async () => {

--- a/src/services/roles/roles.service.ts
+++ b/src/services/roles/roles.service.ts
@@ -11,6 +11,7 @@ import { SessionsService } from 'src/services/sessions/sessions.service';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 import { serializeError } from 'src/common/utils/logger-format.util';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class RolesService {
@@ -65,13 +66,15 @@ export class RolesService {
 
   async findOne(id: string): Promise<RoleEntity> {
     const role = await this.roleRepository.findOneById(id);
-    if (!role) throw new RolesException(`Role with id ${id} not found`, RolesErrorCodes.ROLES_NOT_FOUND, HttpStatus.NOT_FOUND);
+    if (!role)
+      throw new RolesException(`Role with id ${id} not found`, RolesErrorCodes.ROLES_NOT_FOUND, HttpStatus.NOT_FOUND);
     return role;
   }
 
-  async findAll(): Promise<RoleEntity[]> {
+  async findAll(query: PaginationQueryDto = new PaginationQueryDto()): Promise<PaginatedResponseDto<RoleEntity>> {
     try {
-      return await this.roleRepository.findAll();
+      const [data, total] = await this.roleRepository.findAll(query);
+      return new PaginatedResponseDto(data, total, query.page, query.limit);
     } catch (error) {
       throw new RolesException(
         'Roles not found',

--- a/src/services/users/users.controller.spec.ts
+++ b/src/services/users/users.controller.spec.ts
@@ -6,6 +6,8 @@ import { AuthInterface } from 'src/interfaces/auth.interface';
 import { AssignRoleDTO } from 'src/interfaces/DTO/assign.dto';
 import { ForgotPasswordDTO, ResetPasswordDTO } from 'src/interfaces/DTO/reset-password.dto';
 import { ActivateUserDTO } from 'src/interfaces/DTO/activate.dto';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
+import { UserEntity } from 'src/entities/user.entity';
 
 describe('UsersController', () => {
   let controller: UsersController;
@@ -115,18 +117,25 @@ describe('UsersController', () => {
     });
   });
 
-  it('should return all users', async () => {
+  it('should return all users as a paginated response', async () => {
     const users = [
       {
         id: userId,
         email: 'user@example.com',
         person_id: '77777777-7777-7777-7777-777777777777',
       },
-    ] as any;
-    service.findAll.mockResolvedValue(users);
+    ] as UserEntity[];
+    const query = new PaginationQueryDto();
+    const paginated = new PaginatedResponseDto(users, 1, query.page, query.limit);
+    service.findAll.mockResolvedValue(paginated);
 
-    await expect(controller.findAll()).resolves.toEqual(users);
-    expect(service.findAll).toHaveBeenCalledTimes(1);
+    const result = await controller.findAll(query);
+    expect(result.data).toEqual(users);
+    expect(result.total).toBe(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBe(1);
+    expect(service.findAll).toHaveBeenCalledWith(query);
   });
 
   it('should assign roles to the user', async () => {

--- a/src/services/users/users.controller.ts
+++ b/src/services/users/users.controller.ts
@@ -29,11 +29,14 @@ import {
   ApiSecurity,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiExtraModels,
+  getSchemaPath,
 } from '@nestjs/swagger';
 import * as requestUser from 'src/interfaces/request-user';
 import { UsersService } from 'src/services/users/users.service';
 import { UserEntity } from 'src/entities/user.entity';
 import { RegisterUserDTO } from 'src/interfaces/DTO/register.dto';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 import { LoginDTO } from 'src/interfaces/DTO/login.dto';
 import { AssignRoleDTO } from 'src/interfaces/DTO/assign.dto';
 import { ApiKeyGuard } from 'src/common/guards/api-key.guard';
@@ -272,11 +275,25 @@ export class UsersController {
   @UseInterceptors(ClassSerializerInterceptor)
   @ApiCookieAuth('auth_token')
   @ApiOperation({ summary: 'Find all users' })
-  @ApiOkResponse({ type: [UserEntity] })
+  @ApiQuery({ name: 'page', required: false, type: Number, example: 1 })
+  @ApiQuery({ name: 'limit', required: false, type: Number, example: 20 })
+  @ApiExtraModels(UserEntity)
+  @ApiOkResponse({
+    description: 'Paginated list of users',
+    schema: {
+      properties: {
+        data: { type: 'array', items: { $ref: getSchemaPath(UserEntity) } },
+        total: { type: 'integer', example: 42 },
+        page: { type: 'integer', example: 1 },
+        limit: { type: 'integer', example: 20 },
+        totalPages: { type: 'integer', example: 3 },
+      },
+    },
+  })
   @ApiUnauthorizedResponse({ description: 'Missing or invalid auth cookie' })
   @ApiForbiddenResponse({ description: 'Insufficient permissions' })
   @Get('all')
-  findAll(): Promise<UserEntity[]> {
-    return this.userService.findAll();
+  findAll(@Query() query: PaginationQueryDto): Promise<PaginatedResponseDto<UserEntity>> {
+    return this.userService.findAll(query);
   }
 }

--- a/src/services/users/users.repository.ts
+++ b/src/services/users/users.repository.ts
@@ -33,6 +33,7 @@ export class UsersRepository {
       relations: ['roles'],
       skip: (page - 1) * limit,
       take: limit,
+      order: { email: 'ASC' },
     });
   }
 

--- a/src/services/users/users.repository.ts
+++ b/src/services/users/users.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserEntity } from 'src/entities/user.entity';
 import { EntityManager, Repository } from 'typeorm';
+import { PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 @Injectable()
 export class UsersRepository {
@@ -26,8 +27,13 @@ export class UsersRepository {
     return await this.ormRepository.findOneBy({ id });
   }
 
-  async findAll(): Promise<UserEntity[]> {
-    return await this.ormRepository.find({ relations: ['roles'] });
+  async findAll(query: PaginationQueryDto): Promise<[UserEntity[], number]> {
+    const { page, limit } = query;
+    return await this.ormRepository.findAndCount({
+      relations: ['roles'],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
   }
 
   private getManager(manager?: EntityManager): Repository<UserEntity> {

--- a/src/services/users/users.service.spec.ts
+++ b/src/services/users/users.service.spec.ts
@@ -9,6 +9,7 @@ import { UserEntity, UserStatus } from 'src/entities/user.entity';
 import { RedisService } from 'src/common/redis/redis.service';
 import { RegisterUserDTO } from 'src/interfaces/DTO/register.dto';
 import { SessionsService } from 'src/services/sessions/sessions.service';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 
 jest.mock('bcrypt', () => ({
   compare: jest.fn(),
@@ -490,12 +491,20 @@ describe('UsersService', () => {
   });
 
   describe('findAll', () => {
-    it('delegates to userRepository.findAll', async () => {
+    it('returns a PaginatedResponseDto wrapping users from repository', async () => {
       const users = [{ id: 'u-1' }, { id: 'u-2' }] as UserEntity[];
-      (userRepository.findAll as jest.Mock).mockResolvedValue(users);
+      (userRepository.findAll as jest.Mock).mockResolvedValue([users, 2]);
 
-      await expect(service.findAll()).resolves.toEqual(users);
-      expect(userRepository.findAll).toHaveBeenCalledTimes(1);
+      const query = new PaginationQueryDto();
+      const result = await service.findAll(query);
+
+      expect(result).toBeInstanceOf(PaginatedResponseDto);
+      expect(result.data).toEqual(users);
+      expect(result.total).toBe(2);
+      expect(result.page).toBe(1);
+      expect(result.limit).toBe(20);
+      expect(result.totalPages).toBe(1);
+      expect(userRepository.findAll).toHaveBeenCalledWith(query);
     });
   });
 

--- a/src/services/users/users.service.ts
+++ b/src/services/users/users.service.ts
@@ -23,6 +23,7 @@ import { ResetPasswordRedisPayload } from 'src/interfaces/payload';
 import { UsersRepository } from 'src/services/users/users.repository';
 import { ActivateUserDTO } from 'src/interfaces/DTO/activate.dto';
 import { UsersErrorCodes, UsersException } from 'src/services/users/users.exception';
+import { PaginatedResponseDto, PaginationQueryDto } from 'src/interfaces/DTO/pagination.dto';
 import { SessionsService } from 'src/services/sessions/sessions.service';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
@@ -310,13 +311,15 @@ export class UsersService {
     return { message: 'User deactivated successfully' };
   }
 
-  async findAll(): Promise<UserEntity[]> {
-    return await this.userRepository.findAll();
+  async findAll(query: PaginationQueryDto = new PaginationQueryDto()): Promise<PaginatedResponseDto<UserEntity>> {
+    const [data, total] = await this.userRepository.findAll(query);
+    return new PaginatedResponseDto(data, total, query.page, query.limit);
   }
 
   private async findOne(id: string): Promise<UserEntity> {
     const user = await this.userRepository.findOneById(id);
-    if (!user) throw new UsersException(`User with id ${id} not found`, UsersErrorCodes.USER_NOT_FOUND, HttpStatus.NOT_FOUND);
+    if (!user)
+      throw new UsersException(`User with id ${id} not found`, UsersErrorCodes.USER_NOT_FOUND, HttpStatus.NOT_FOUND);
     return user;
   }
 

--- a/test/integration/pg-mem/permissions.spec.ts
+++ b/test/integration/pg-mem/permissions.spec.ts
@@ -110,5 +110,19 @@ describe('PermissionsService (integration)', () => {
     const stored = await repository.findOneBy({ id: created.id });
     expect(stored).toBeNull();
   });
+
+  it('findAll returns a paginated response of permissions', async () => {
+    const created = await service.create({ code: 'PAGINATED_PERM' }, request);
+
+    const result = await service.findAll({ page: 1, limit: 20 });
+
+    expect(result.data).toBeDefined();
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
+    const codes = result.data.map((p) => p.code);
+    expect(codes).toContain('PAGINATED_PERM');
+  });
 });
 const request = { user: null } as any;

--- a/test/integration/pg-mem/roles.spec.ts
+++ b/test/integration/pg-mem/roles.spec.ts
@@ -153,4 +153,18 @@ describe('RolesService (integration)', () => {
     const exists = await roleRepository.findOneBy({ id: role.id });
     expect(exists).toBeNull();
   });
+
+  it('findAll returns a paginated response of roles', async () => {
+    await service.create({ name: 'paginated-role' }, request);
+
+    const result = await service.findAll({ page: 1, limit: 20 });
+
+    expect(result.data).toBeDefined();
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
+    const names = result.data.map((r) => r.name);
+    expect(names).toContain('paginated-role');
+  });
 });

--- a/test/integration/pg-mem/users.spec.ts
+++ b/test/integration/pg-mem/users.spec.ts
@@ -433,13 +433,17 @@ describe('UsersService (integration)', () => {
     expect(redisServiceMock.raw.sRem).toHaveBeenCalledWith('user_sessions:user-1', 'sess-logout');
   });
 
-  it('findAll returns all registered users', async () => {
+  it('findAll returns a paginated response containing registered users', async () => {
     await usersService.register({ email: 'julia@example.com', person_id: randomUUID() }, request);
 
-    const users = await usersService.findAll();
-    const emails = users.map((u) => u.email);
+    const result = await usersService.findAll({ page: 1, limit: 20 });
 
+    expect(result.data).toBeDefined();
+    const emails = result.data.map((u) => u.email);
     expect(emails).toContain('julia@example.com');
-    expect(users.length).toBeGreaterThanOrEqual(1);
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
   });
 });

--- a/test/integration/testcontainers/api-keys.spec.ts
+++ b/test/integration/testcontainers/api-keys.spec.ts
@@ -251,4 +251,19 @@ describe('ApiKeysService (integration)', () => {
     expect(redisMultiMock.set).toHaveBeenCalled();
     expect(redisMultiMock.sAdd).toHaveBeenCalled();
   });
+
+  it('findAll returns a paginated response of API keys', async () => {
+    const permission = await permissionsService.create({ code: 'FINDALL_PERM' }, request);
+    await service.create({ client: 'findall-client', permissionIds: [permission.id] }, request);
+
+    const result = await service.findAll({ page: 1, limit: 20 });
+
+    expect(result.data).toBeDefined();
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
+    const clients = result.data.map((k) => k.client);
+    expect(clients).toContain('findall-client');
+  });
 });

--- a/test/integration/testcontainers/permissions.spec.ts
+++ b/test/integration/testcontainers/permissions.spec.ts
@@ -98,4 +98,18 @@ describe('PermissionsService (integration)', () => {
     const stored = await repository.findOneBy({ id: created.id });
     expect(stored).toBeNull();
   });
+
+  it('findAll returns a paginated response of permissions', async () => {
+    await service.create({ code: 'PAGINATED_PERM' }, request);
+
+    const result = await service.findAll({ page: 1, limit: 20 });
+
+    expect(result.data).toBeDefined();
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
+    const codes = result.data.map((p) => p.code);
+    expect(codes).toContain('PAGINATED_PERM');
+  });
 });

--- a/test/integration/testcontainers/roles.spec.ts
+++ b/test/integration/testcontainers/roles.spec.ts
@@ -135,4 +135,18 @@ describe('RolesService (integration)', () => {
     const exists = await roleRepository.findOneBy({ id: role.id });
     expect(exists).toBeNull();
   });
+
+  it('findAll returns a paginated response of roles', async () => {
+    await service.create({ name: 'paginated-role' }, request);
+
+    const result = await service.findAll({ page: 1, limit: 20 });
+
+    expect(result.data).toBeDefined();
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
+    const names = result.data.map((r) => r.name);
+    expect(names).toContain('paginated-role');
+  });
 });

--- a/test/integration/testcontainers/users.spec.ts
+++ b/test/integration/testcontainers/users.spec.ts
@@ -419,13 +419,17 @@ describe('UsersService (integration)', () => {
     expect(redisServiceMock.raw.sRem).toHaveBeenCalledWith('user_sessions:user-1', 'sess-logout');
   });
 
-  it('findAll returns all registered users', async () => {
+  it('findAll returns a paginated response containing registered users', async () => {
     await usersService.register({ email: 'julia@example.com', person_id: randomUUID() }, request);
 
-    const users = await usersService.findAll();
-    const emails = users.map((u) => u.email);
+    const result = await usersService.findAll({ page: 1, limit: 20 });
 
+    expect(result.data).toBeDefined();
+    const emails = result.data.map((u) => u.email);
     expect(emails).toContain('julia@example.com');
-    expect(users.length).toBeGreaterThanOrEqual(1);
+    expect(result.total).toBeGreaterThanOrEqual(1);
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(20);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
# 🚀 PR: Implement Pagination Across All List Endpoints

## 📌 Overview

This Pull Request introduces a **standardized pagination mechanism** across all `findAll` endpoints in the system. The implementation ensures consistency, scalability, and improved API usability by returning structured paginated responses for all core domains.

Additionally, this PR includes a **critical fix** to guarantee deterministic ordering in paginated queries, preventing inconsistent results across pages.

---

## 🧩 Key Changes

### 1. Shared Pagination DTOs

- Introduced a reusable `PaginationQueryDto`:
  - Handles `page` and `limit` query parameters with validation.
- Added a generic `PaginatedResponseDto<T>`:
  - Standard response shape:
    ```ts
    {
      data: T[],
      total: number,
      page: number,
      limit: number,
      totalPages: number
    }
    ```

---

### 2. Domain-Level Pagination Implementation

Pagination was implemented consistently across all major domains:

- **Users**
- **Roles**
- **Permissions**
- **API Keys**
- **Endpoint Permission Rules**

#### Repository Layer
- Updated all `findAll()` methods to:
  - Accept `PaginationQueryDto`
  - Use `findAndCount({ skip, take })`
  - Return `[entities, total]`
  - ✅ **NEW:** Added explicit `order` clause to ensure deterministic sorting

#### Service Layer
- Transforms repository output into `PaginatedResponseDto<T>`
- Preserves domain-specific logic (e.g., `RolesService` error handling)

#### Controller Layer
- Accepts pagination query params via `@Query()`
- Swagger documentation updated:
  - `@ApiQuery` for `page` and `limit`
  - `@ApiOkResponse` updated to reflect paginated structure

---

### 🛠️ Fix: Deterministic Ordering in Pagination

#### ❗ Problem

The initial pagination implementation used `skip`/`take` without an explicit `order`, leading to:

- Undefined row ordering at the database level
- Possible **duplicate or missing records across pages**
- Regression compared to non-paginated queries

#### ✅ Resolution

- Added a deterministic `order` clause to **all repository `findAll()` methods**
- Ensures stable and predictable pagination across requests

Example:

```ts
findAndCount({
  skip,
  take,
  order: { name: 'DESC' }
});