### PR TITLE
Feature outbox entity cleanup completed

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -29,6 +29,7 @@ import { AllExceptionsFilter } from 'src/common/filters/all-exceptions.filter';
 import { ObservabilityModule } from 'src/observability/observability.module';
 import { EndpointPermissionRulesModule } from 'src/services/endpoint-permission-rules/endpoint-permission-rules.module';
 import { IsUniqueEndpointKeyNameConstraint } from 'src/common/validators/unique-endpoint-key.validator';
+import { OutboxCleanupService } from 'src/cron/outbox-cleanup.service';
 
 @Module({
   imports: [
@@ -103,6 +104,7 @@ import { IsUniqueEndpointKeyNameConstraint } from 'src/common/validators/unique-
     IsUniqueEndpointKeyNameConstraint,
     OutboxPublisherService,
     OutboxSubscriberService,
+    OutboxCleanupService,
     EprCacheReconciliationService,
     ApiKeysCacheReconciliationService,
   ],

--- a/src/cron/outbox-cleanup.service.ts
+++ b/src/cron/outbox-cleanup.service.ts
@@ -1,0 +1,71 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { OutboxEntity, OutboxStatus } from 'src/entities/outbox.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { serializeError } from 'src/common/utils/logger-format.util';
+
+@Injectable()
+export class OutboxCleanupService {
+  constructor(
+    @InjectRepository(OutboxEntity)
+    private readonly outboxRepository: Repository<OutboxEntity>,
+
+    @Inject(WINSTON_MODULE_PROVIDER)
+    private readonly logger: Logger,
+  ) {}
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  private async handleOutboxCleanup(): Promise<void> {
+    this.logger.info('Cleaning up sent outbox messages started', {
+      context: 'OutboxCleanupService',
+      operation: 'cleanSentOutboxMessages',
+    });
+
+    const BATCH_SIZE = 1000;
+    let totalDeleted = 0;
+    let affected = 0;
+
+
+    try {
+      do {
+
+        const subQuery = this.outboxRepository.createQueryBuilder('sub_outbox')
+          .select('sub_outbox.id')
+          .where('sub_outbox.status = :status', { status: OutboxStatus.SENT })
+          .limit(BATCH_SIZE);
+
+        const result = await this.outboxRepository.createQueryBuilder()
+          .delete()
+          .from(OutboxEntity)
+          .where(`id IN (${subQuery.getQuery()})`)
+          .setParameters(subQuery.getParameters())
+          .execute();
+
+        affected = result.affected || 0;
+        totalDeleted += affected;
+
+        this.logger.info(`Deleted ${affected} outbox messages`, {
+          context: 'OutboxCleanupService',
+          operation: 'cleanSentOutboxMessages',
+        });
+
+      } while (affected === BATCH_SIZE);
+
+      this.logger.info('Cleaning up sent outbox messages completed', {
+        context: 'OutboxCleanupService',
+        operation: 'cleanSentOutboxMessages',
+        totalDeleted,
+      });
+
+    } catch (error) {
+      this.logger.warn('Failed to clean up sent outbox messages', {
+        context: 'OutboxCleanupService',
+        operation: 'cleanSentOutboxMessages',
+        error: serializeError(error),
+      })
+    }
+  }
+}

--- a/src/entities/outbox.entity.ts
+++ b/src/entities/outbox.entity.ts
@@ -1,4 +1,4 @@
-import { Column, CreateDateColumn, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
 
 export enum OutboxStatus {
   PENDING = 'PENDING',
@@ -6,6 +6,7 @@ export enum OutboxStatus {
   FAILED = 'FAILED',
 }
 
+@Index('idx_outbox_sent_cleanup', ['status'], { where: '"status" = \'SENT\'' })
 @Entity('outbox')
 export class OutboxEntity {
   @PrimaryGeneratedColumn('uuid')


### PR DESCRIPTION
This pull request introduces a new scheduled service for cleaning up sent outbox messages from the database, improving system hygiene and long-term performance. The core change is the addition of a daily cron job that efficiently deletes batches of sent outbox records. Supporting changes include registering the new service in the application module and optimizing the database with an index for faster cleanup queries.

**Outbox cleanup feature:**

* Added a new `OutboxCleanupService` that runs daily at midnight to delete sent outbox messages in batches, with robust logging and error handling. (`src/cron/outbox-cleanup.service.ts`)
* Registered `OutboxCleanupService` as a provider in the application module, ensuring it is instantiated and scheduled at runtime. (`src/app.module.ts`) [[1]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R32) [[2]](diffhunk://#diff-089f4f2474b64391c42b6e66aed33977e132058d92108f0a63234a7862e1f8b8R107)

**Database optimization:**

* Added a partial index `idx_outbox_sent_cleanup` on the `status` column of the `outbox` table for rows where status is `SENT`, improving the performance of cleanup queries. (`src/entities/outbox.entity.ts`)