### PR TITLE
Hotfix: Refactor user can-do permission check workflow

### DIFF
--- a/src/services/users/users.service.spec.ts
+++ b/src/services/users/users.service.spec.ts
@@ -112,7 +112,7 @@ describe('UsersService', () => {
 
       await expect(
         service.canDo({ session_id: 'abc', id: '1', email: '', person_id: '' }, 'DELETE_USER'),
-      ).rejects.toBeInstanceOf(UsersException);
+      ).resolves.toBe(false);
     });
   });
 

--- a/src/services/users/users.service.ts
+++ b/src/services/users/users.service.ts
@@ -79,13 +79,7 @@ export class UsersService {
       throw new UsersException('Session expired or invalid', UsersErrorCodes.SESSION_INVALID, HttpStatus.UNAUTHORIZED);
     }
 
-    const allowed = session.permissions.includes(permissionCode);
-
-    if (!allowed) {
-      throw new UsersException('Insufficient permissions', UsersErrorCodes.INSUFFICIENT_PERMISSIONS, HttpStatus.FORBIDDEN);
-    }
-
-    return allowed;
+    return session.permissions.includes(permissionCode);
   }
 
   async register(dto: RegisterUserDTO, request: RequestWithUser): Promise<{ message: string }> {


### PR DESCRIPTION
This pull request updates the `UsersService` permission checking logic to return a boolean instead of throwing an exception when a user lacks the required permission. It also updates the corresponding unit test to expect a `false` result rather than an exception.

Permission checking changes:

* The `canDo` method in `UsersService` now returns `false` when the user does not have the required permission, instead of throwing a `UsersException`.

Testing updates:

* The `UsersService` unit test for insufficient permissions now expects `canDo` to resolve to `false` instead of rejecting with a `UsersException`.