### PR TITLE
Fix: update UUID validation version for `person_id` in `register.dto`

### DIFF
--- a/src/interfaces/DTO/register.dto.ts
+++ b/src/interfaces/DTO/register.dto.ts
@@ -11,7 +11,7 @@ export class RegisterUserDTO {
   email: string;
 
   @ApiProperty({ description: 'Associated person ID', example: '550e8400-e29b-41d4-a716-446655440000' })
-  @IsUUID('4', { message: 'person_id must be a valid UUID' })
+  @IsUUID('7', { message: 'person_id must be a valid UUID' })
   @IsNotEmpty({ message: 'This field is required' })
   @IsUniquePerson()
   person_id: string;


### PR DESCRIPTION
This pull request updates the validation for the `person_id` field in the `RegisterUserDTO` data transfer object. The most important change is:

Validation update:

* Changed the `@IsUUID` decorator on `person_id` from requiring a version 4 UUID to requiring a version 7 UUID, ensuring that only version 7 UUIDs are considered valid for this field.